### PR TITLE
Replaces sleep with ticker to address blocking issues

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -62,6 +62,7 @@ func TestWaitOnPreviousBuilds(t *testing.T) {
 	assert.Equal(t, bm.buildToWatchBranch, "my-branch")
 
 	finishedBuilds := *bm.finishedBuildCalls
+
 	assert.Equal(t, finishedBuilds[0].UUID, "1")
 	assert.Equal(t, finishedBuilds[1].UUID, "2")
 	assert.Equal(t, finishedBuilds[2].UUID, "3")


### PR DESCRIPTION
Currently, if you press control-c while waiter is sleeping, it will block until the 30 second sleep is up.

This PR removes the sleep and replaces it with a ticker.

@markphelps This should address the blocking concerns you mentioned. 

**NOTE**: This PR branches off of #3 